### PR TITLE
Track support

### DIFF
--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -63,6 +63,7 @@ SatisMeter.prototype.identify = function(identify) {
   window.satismeter({
     writeKey: this.options.apiKey || this.options.token,
     userId: identify.userId(),
+    anonymousId: identify.anonymousId(),
     traits: this.analytics.user().traits(),
     type: 'identify'
   });
@@ -78,6 +79,7 @@ SatisMeter.prototype.identify = function(identify) {
 SatisMeter.prototype.page = function(page) {
   window.satismeter('page', {
     userId: this.analytics.user().id(),
+    anonymousId: this.analytics.user().anonymousId(),
     name: page.name(),
     category: page.category(),
     properties: page.properties()
@@ -94,6 +96,7 @@ SatisMeter.prototype.page = function(page) {
 SatisMeter.prototype.track = function(track) {
   window.satismeter('track', {
     userId: this.analytics.user().id(),
+    anonymousId: this.analytics.user().anonymousId(),
     event: track.event(),
     properties: track.properties()
   });
@@ -109,6 +112,7 @@ SatisMeter.prototype.track = function(track) {
 SatisMeter.prototype.group = function(group) {
   window.satismeter('group', {
     userId: this.analytics.user().id(),
+    anonymousId: this.analytics.user().anonymousId(),
     groupId: group.groupId(),
     traits: group.properties()
   });

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -60,12 +60,10 @@ SatisMeter.prototype.loaded = function() {
  */
 
 SatisMeter.prototype.identify = function(identify) {
-  window.satismeter({
-    writeKey: this.options.apiKey || this.options.token,
+  window.satismeter('identify', {
     userId: identify.userId(),
     anonymousId: identify.anonymousId(),
-    traits: this.analytics.user().traits(),
-    type: 'identify'
+    traits: this.analytics.user().traits()
   });
 };
 

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -60,11 +60,10 @@ SatisMeter.prototype.loaded = function() {
  */
 
 SatisMeter.prototype.identify = function(identify) {
-  window.satismeter({
+  window.satismeter('identify', {
     writeKey: this.options.apiKey || this.options.token,
     userId: identify.userId(),
-    traits: this.analytics.user().traits(),
-    type: 'identify'
+    traits: this.analytics.user().traits()
   });
 };
 

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -83,3 +83,35 @@ SatisMeter.prototype.page = function(page) {
     properties: page.properties()
   });
 };
+
+/**
+ * Track.
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+SatisMeter.prototype.track = function(track) {
+  window.satismeter('track', {
+    writeKey: this.options.apiKey || this.options.token,
+    userId: this.analytics.user().id(),
+    event: track.event(),
+    properties: track.properties()
+  });
+};
+
+/**
+ * group.
+ *
+ * @api public
+ * @param {group} group
+ */
+
+SatisMeter.prototype.group = function(group) {
+  window.satismeter('group', {
+    writeKey: this.options.apiKey || this.options.token,
+    userId: this.analytics.user().id(),
+    groupId: group.groupId(),
+    traits: group.properties()
+  });
+};

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -93,7 +93,6 @@ SatisMeter.prototype.page = function(page) {
 
 SatisMeter.prototype.track = function(track) {
   window.satismeter('track', {
-    writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
     event: track.event(),
     properties: track.properties()
@@ -109,7 +108,6 @@ SatisMeter.prototype.track = function(track) {
 
 SatisMeter.prototype.group = function(group) {
   window.satismeter('group', {
-    writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
     groupId: group.groupId(),
     traits: group.properties()

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -33,7 +33,8 @@ SatisMeter.prototype.initialize = function() {
       },
       function() {
         window.satismeter('load', {
-          writeKey: options.apiKey || options.token
+          writeKey: options.apiKey || options.token,
+          source: 'analytics.js'
         });
         self.ready();
       }

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -77,7 +77,6 @@ SatisMeter.prototype.identify = function(identify) {
 
 SatisMeter.prototype.page = function(page) {
   window.satismeter('page', {
-    writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
     name: page.name(),
     category: page.category(),

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -74,10 +74,12 @@ SatisMeter.prototype.identify = function(identify) {
  * @param {Page} page
  */
 
-SatisMeter.prototype.page = function() {
-  window.satismeter({
+SatisMeter.prototype.page = function(page) {
+  window.satismeter('page', {
     writeKey: this.options.apiKey || this.options.token,
     userId: this.analytics.user().id(),
-    type: 'page'
+    name: page.name(),
+    category: page.category(),
+    properties: page.properties()
   });
 };

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -25,10 +25,19 @@ var SatisMeter = (module.exports = integration('SatisMeter')
 
 SatisMeter.prototype.initialize = function() {
   var self = this;
+  var options = this.options;
   this.load(function() {
-    when(function() {
-      return self.loaded();
-    }, self.ready);
+    when(
+      function() {
+        return self.loaded();
+      },
+      function() {
+        window.satismeter('load', {
+          writeKey: options.apiKey || options.token
+        });
+        self.ready();
+      }
+    );
   });
 };
 

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -60,10 +60,11 @@ SatisMeter.prototype.loaded = function() {
  */
 
 SatisMeter.prototype.identify = function(identify) {
-  window.satismeter('identify', {
+  window.satismeter({
     writeKey: this.options.apiKey || this.options.token,
     userId: identify.userId(),
-    traits: this.analytics.user().traits()
+    traits: this.analytics.user().traits(),
+    type: 'identify'
   });
 };
 

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -130,6 +130,29 @@ describe('SatisMeter', function() {
       });
     });
 
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send event name and properties', function() {
+        analytics.user().id('id');
+        analytics.track('User Subscribed', {
+          planId: 'Example Plan',
+          planPrice: 2000
+        });
+        analytics.called(window.satismeter, 'track', {
+          writeKey: options.apiKey,
+          userId: 'id',
+          event: 'User Subscribed',
+          properties: {
+            planId: 'Example Plan',
+            planPrice: 2000
+          }
+        });
+      });
+    });
+
     describe('#page', function() {
       beforeEach(function() {
         analytics.stub(window, 'satismeter');
@@ -154,6 +177,29 @@ describe('SatisMeter', function() {
             title: window.document.title,
             url: window.location.href,
             customProperty: 'Example'
+          }
+        });
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send group id and traits', function() {
+        analytics.user().id('id');
+        analytics.group('groupId', {
+          industry: 'Technology',
+          employees: 2000
+        });
+        analytics.called(window.satismeter, 'group', {
+          writeKey: options.apiKey,
+          userId: 'id',
+          groupId: 'groupId',
+          traits: {
+            industry: 'Technology',
+            employees: 2000
           }
         });
       });
@@ -286,6 +332,29 @@ describe('SatisMeter - legacy setup', function() {
       });
     });
 
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send event name and properties', function() {
+        analytics.user().id('id');
+        analytics.track('User Subscribed', {
+          planId: 'Example Plan',
+          planPrice: 2000
+        });
+        analytics.called(window.satismeter, 'track', {
+          writeKey: options.token,
+          userId: 'id',
+          event: 'User Subscribed',
+          properties: {
+            planId: 'Example Plan',
+            planPrice: 2000
+          }
+        });
+      });
+    });
+
     describe('#page', function() {
       beforeEach(function() {
         analytics.stub(window, 'satismeter');
@@ -310,6 +379,29 @@ describe('SatisMeter - legacy setup', function() {
             title: window.document.title,
             url: window.location.href,
             customProperty: 'Example'
+          }
+        });
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send group id and traits', function() {
+        analytics.user().id('id');
+        analytics.group('groupId', {
+          industry: 'Technology',
+          employees: 2000
+        });
+        analytics.called(window.satismeter, 'group', {
+          writeKey: options.token,
+          userId: 'id',
+          groupId: 'groupId',
+          traits: {
+            industry: 'Technology',
+            employees: 2000
           }
         });
       });

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -45,6 +45,7 @@ describe('SatisMeter', function() {
     describe('#initialize', function() {
       it('should call #load', function() {
         analytics.initialize();
+
         analytics.called(satismeter.load);
       });
     });
@@ -69,9 +70,12 @@ describe('SatisMeter', function() {
 
       it('should send apiKey and user id', function() {
         analytics.identify('id');
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {},
           type: 'identify'
         });
@@ -79,9 +83,12 @@ describe('SatisMeter', function() {
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
           },
@@ -91,9 +98,12 @@ describe('SatisMeter', function() {
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             name: 'john doe'
           },
@@ -104,9 +114,12 @@ describe('SatisMeter', function() {
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             createdAt: now
           },
@@ -121,9 +134,12 @@ describe('SatisMeter', function() {
           },
           language: 'en'
         });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             translation: {
               FOLLOWUP: 'What can we improve'
@@ -142,12 +158,15 @@ describe('SatisMeter', function() {
 
       it('should send event name and properties', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.track('User Subscribed', {
           planId: 'Example Plan',
           planPrice: 2000
         });
+
         analytics.called(window.satismeter, 'track', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           event: 'User Subscribed',
           properties: {
             planId: 'Example Plan',
@@ -164,11 +183,14 @@ describe('SatisMeter', function() {
 
       it('should send page name, category and properties', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.page('Product', 'Pricing', {
           customProperty: 'Example'
         });
+
         analytics.called(window.satismeter, 'page', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           name: 'Pricing',
           category: 'Product',
           properties: {
@@ -192,12 +214,15 @@ describe('SatisMeter', function() {
 
       it('should send group id and traits', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.group('groupId', {
           industry: 'Technology',
           employees: 2000
         });
+
         analytics.called(window.satismeter, 'group', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           groupId: 'groupId',
           traits: {
             industry: 'Technology',
@@ -249,6 +274,7 @@ describe('SatisMeter - legacy setup', function() {
     describe('#initialize', function() {
       it('should call #load', function() {
         analytics.initialize();
+
         analytics.called(satismeter.load);
       });
     });
@@ -273,9 +299,12 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send token and user id', function() {
         analytics.identify('id');
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {},
           type: 'identify'
         });
@@ -283,9 +312,12 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
           },
@@ -295,9 +327,12 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             name: 'john doe'
           },
@@ -308,9 +343,12 @@ describe('SatisMeter - legacy setup', function() {
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             createdAt: now
           },
@@ -325,9 +363,12 @@ describe('SatisMeter - legacy setup', function() {
           },
           language: 'en'
         });
+        var anonymousId = analytics.user().anonymousId();
+
         analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             translation: {
               FOLLOWUP: 'What can we improve'
@@ -346,12 +387,15 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send event name and properties', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.track('User Subscribed', {
           planId: 'Example Plan',
           planPrice: 2000
         });
+
         analytics.called(window.satismeter, 'track', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           event: 'User Subscribed',
           properties: {
             planId: 'Example Plan',
@@ -368,11 +412,14 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send page name, category and properties', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.page('Product', 'Pricing', {
           customProperty: 'Example'
         });
+
         analytics.called(window.satismeter, 'page', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           name: 'Pricing',
           category: 'Product',
           properties: {
@@ -396,12 +443,15 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send group id and traits', function() {
         analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
         analytics.group('groupId', {
           industry: 'Technology',
           employees: 2000
         });
+
         analytics.called(window.satismeter, 'group', {
           userId: 'id',
+          anonymousId: 'anonymousId',
           groupId: 'groupId',
           traits: {
             industry: 'Technology',

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -168,7 +168,6 @@ describe('SatisMeter', function() {
           customProperty: 'Example'
         });
         analytics.called(window.satismeter, 'page', {
-          writeKey: options.apiKey,
           userId: 'id',
           name: 'Pricing',
           category: 'Product',
@@ -373,7 +372,6 @@ describe('SatisMeter - legacy setup', function() {
           customProperty: 'Example'
         });
         analytics.called(window.satismeter, 'page', {
-          writeKey: options.token,
           userId: 'id',
           name: 'Pricing',
           category: 'Product',

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -72,12 +72,10 @@ describe('SatisMeter', function() {
         analytics.identify('id');
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
-          traits: {},
-          type: 'identify'
+          traits: {}
         });
       });
 
@@ -85,14 +83,12 @@ describe('SatisMeter', function() {
         analytics.identify('id', { email: 'email@example.com' });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -100,14 +96,12 @@ describe('SatisMeter', function() {
         analytics.identify('id', { name: 'john doe' });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -116,14 +110,12 @@ describe('SatisMeter', function() {
         analytics.identify('id', { createdAt: now });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -136,8 +128,7 @@ describe('SatisMeter', function() {
         });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
@@ -145,8 +136,7 @@ describe('SatisMeter', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
         });
       });
     });
@@ -301,12 +291,10 @@ describe('SatisMeter - legacy setup', function() {
         analytics.identify('id');
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
-          traits: {},
-          type: 'identify'
+          traits: {}
         });
       });
 
@@ -314,14 +302,12 @@ describe('SatisMeter - legacy setup', function() {
         analytics.identify('id', { email: 'email@example.com' });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -329,14 +315,12 @@ describe('SatisMeter - legacy setup', function() {
         analytics.identify('id', { name: 'john doe' });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -345,14 +329,12 @@ describe('SatisMeter - legacy setup', function() {
         analytics.identify('id', { createdAt: now });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -365,8 +347,7 @@ describe('SatisMeter - legacy setup', function() {
         });
         var anonymousId = analytics.user().anonymousId();
 
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
           anonymousId: anonymousId,
           traits: {
@@ -374,8 +355,7 @@ describe('SatisMeter - legacy setup', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
         });
       });
     });

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -69,48 +69,44 @@ describe('SatisMeter', function() {
 
       it('should send apiKey and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.apiKey,
           userId: 'id',
-          traits: {},
-          type: 'identify'
+          traits: {}
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -121,7 +117,7 @@ describe('SatisMeter', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
@@ -129,8 +125,7 @@ describe('SatisMeter', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
         });
       });
     });
@@ -215,50 +210,46 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send token and user id', function() {
+      it('should send apiKey and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.token,
           userId: 'id',
-          traits: {},
-          type: 'identify'
+          traits: {}
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.token,
           userId: 'id',
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.token,
           userId: 'id',
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.token,
           userId: 'id',
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -269,7 +260,7 @@ describe('SatisMeter - legacy setup', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, {
+        analytics.called(window.satismeter, 'identify', {
           writeKey: options.token,
           userId: 'id',
           traits: {
@@ -277,8 +268,7 @@ describe('SatisMeter - legacy setup', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
         });
       });
     });

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -142,7 +142,6 @@ describe('SatisMeter', function() {
           planPrice: 2000
         });
         analytics.called(window.satismeter, 'track', {
-          writeKey: options.apiKey,
           userId: 'id',
           event: 'User Subscribed',
           properties: {
@@ -194,7 +193,6 @@ describe('SatisMeter', function() {
           employees: 2000
         });
         analytics.called(window.satismeter, 'group', {
-          writeKey: options.apiKey,
           userId: 'id',
           groupId: 'groupId',
           traits: {
@@ -344,7 +342,6 @@ describe('SatisMeter - legacy setup', function() {
           planPrice: 2000
         });
         analytics.called(window.satismeter, 'track', {
-          writeKey: options.token,
           userId: 'id',
           event: 'User Subscribed',
           properties: {
@@ -396,7 +393,6 @@ describe('SatisMeter - legacy setup', function() {
           employees: 2000
         });
         analytics.called(window.satismeter, 'group', {
-          writeKey: options.token,
           userId: 'id',
           groupId: 'groupId',
           traits: {

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -69,44 +69,48 @@ describe('SatisMeter', function() {
 
       it('should send apiKey and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
-          traits: {}
+          traits: {},
+          type: 'identify'
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             email: 'email@example.com'
-          }
+          },
+          type: 'identify'
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             name: 'john doe'
-          }
+          },
+          type: 'identify'
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
             createdAt: now
-          }
+          },
+          type: 'identify'
         });
       });
 
@@ -117,7 +121,7 @@ describe('SatisMeter', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.apiKey,
           userId: 'id',
           traits: {
@@ -125,7 +129,8 @@ describe('SatisMeter', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          }
+          },
+          type: 'identify'
         });
       });
     });
@@ -267,46 +272,50 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send apiKey and user id', function() {
+      it('should send token and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
-          traits: {}
+          traits: {},
+          type: 'identify'
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
           traits: {
             email: 'email@example.com'
-          }
+          },
+          type: 'identify'
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
           traits: {
             name: 'john doe'
-          }
+          },
+          type: 'identify'
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
           traits: {
             createdAt: now
-          }
+          },
+          type: 'identify'
         });
       });
 
@@ -317,7 +326,7 @@ describe('SatisMeter - legacy setup', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, 'identify', {
+        analytics.called(window.satismeter, {
           writeKey: options.token,
           userId: 'id',
           traits: {
@@ -325,7 +334,8 @@ describe('SatisMeter - legacy setup', function() {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          }
+          },
+          type: 'identify'
         });
       });
     });

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -135,13 +135,26 @@ describe('SatisMeter', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send apiKey and user id', function() {
+      it('should send page name, category and properties', function() {
         analytics.user().id('id');
-        analytics.page('Pricing');
-        analytics.called(window.satismeter, {
+        analytics.page('Product', 'Pricing', {
+          customProperty: 'Example'
+        });
+        analytics.called(window.satismeter, 'page', {
           writeKey: options.apiKey,
           userId: 'id',
-          type: 'page'
+          name: 'Pricing',
+          category: 'Product',
+          properties: {
+            name: 'Pricing',
+            category: 'Product',
+            path: window.location.pathname,
+            referrer: window.document.referrer,
+            search: window.location.search,
+            title: window.document.title,
+            url: window.location.href,
+            customProperty: 'Example'
+          }
         });
       });
     });
@@ -278,13 +291,26 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send token and user id', function() {
+      it('should send page name, category and properties', function() {
         analytics.user().id('id');
-        analytics.page('Pricing');
-        analytics.called(window.satismeter, {
+        analytics.page('Product', 'Pricing', {
+          customProperty: 'Example'
+        });
+        analytics.called(window.satismeter, 'page', {
           writeKey: options.token,
           userId: 'id',
-          type: 'page'
+          name: 'Pricing',
+          category: 'Product',
+          properties: {
+            name: 'Pricing',
+            category: 'Product',
+            path: window.location.pathname,
+            referrer: window.document.referrer,
+            search: window.location.search,
+            title: window.document.title,
+            url: window.location.href,
+            customProperty: 'Example'
+          }
         });
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,10 +1457,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.0.tgz#2df0a1f8dad87e13ca4afac51655d6bac7c0c95f"
-  integrity sha512-yOGcYD33y0Wo1qHIA+IFIHcxk0GoRrQwCjpuaKZf2rnz0puZoseSGPdbIX47BgMLSSgEYnBoW3s5aUpCRdkEkw==
+"@segment/tracktor@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.1.tgz#ca3e868f8b51c7da585764a482874addc31ea3e1"
+  integrity sha512-M9/XhBOHzerK1ZoiL/wOaM4gmzBOV6e2Z/xeic85qjKtiFSqNOBthlpyEGfEDKo6niEVBQm6wn86HgcAEkMDAg==
   dependencies:
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"


### PR DESCRIPTION
This PR contains the changes I'll propose on upstream.

Two important things regarding backwards compatibility that we should discuss first:
- I used the new format from satismeter/satismeter#481 for `identify` and `page` as mentioned in Twist. But now I realize that if the format is not yet avalable maybe we shouldn't change it.
- It still passes `writeKey` because of the same reason. If `load` is not yet available it must pass the writeKey on everycall because it cannot rely on `window.satismeter('load', ...)` to store it.

@jsedlacek @jsedlacek What do you think? Do we go with new format (named method + load) only for `track` and `group` or for all of them?